### PR TITLE
0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Now to check the signatures of the callable objects, you need to create a `Signa
 - `"*"` - corresponds to packing multiple positional arguments without default values (*args).
 - `"**"` - corresponds to packing several named arguments with default values (**kwargs).
 
-When you have prepared a `SignatureMatcher` object, you can apply it to function objects and get a response (`True`/`False`) whether their signatures match the expected ones. As an example, see what a function and a `SignatureMatcher` object for it mights look like:
+Note that the arguments can only go in this order, that is, you cannot specify the packing before the positional argument, otherwise you will get an `IncorrectArgumentsOrderError`. When you have prepared a `SignatureMatcher` object, you can apply it to function objects and get a response (`True`/`False`) whether their signatures match the expected ones. As an example, see what a function and a `SignatureMatcher` object for it mights look like:
 
 ```python
 from sigmatch import SignatureMatcher

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ matcher = SignatureMatcher('.', '.', 'c', '*', '**')
 print(matcher.match(function))  # True
 ```
 
-The `match()` method works with both regular and coroutine functions, as well as with lambdas, generators, classes, and many other callable objects. By default, the `match()` method returns a boolean value, but you can ask the library to immediately raise an exception if the function does not have the signature you need:
+The `match()` method works with both regular and coroutine functions, as well as with lambdas, generators, classes, methods, and many other callable objects. By default, the `match()` method returns a boolean value, but you can ask the library to immediately raise an exception if the function does not have the signature you need:
 
 ```python
 matcher.match(function, raise_exception=True)
@@ -53,5 +53,5 @@ from sigmatch import SignatureMatcher, SignatureMismatchError
 try:
     SignatureMatcher('.').match(lambda: None, raise_exception=True)
 except SignatureMismatchError:
-    print('Deal with it (⌐■_■)')
+    print('Deal with it (⌐■_■)')  # It'll be printed.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sigmatch"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Evgeniy Blinov", email="zheni-b@yandex.ru" },
 ]

--- a/sigmatch/__init__.py
+++ b/sigmatch/__init__.py
@@ -1,2 +1,3 @@
 from sigmatch.matcher import SignatureMatcher as SignatureMatcher  # noqa: F401
 from sigmatch.errors import SignatureMismatchError as SignatureMismatchError  # noqa: F401
+from sigmatch.errors import IncorrectArgumentsOrderError as IncorrectArgumentsOrderError  # noqa: F401

--- a/sigmatch/errors.py
+++ b/sigmatch/errors.py
@@ -1,2 +1,5 @@
 class SignatureMismatchError(Exception):
     pass
+
+class IncorrectArgumentsOrderError(Exception):
+    pass

--- a/sigmatch/matcher.py
+++ b/sigmatch/matcher.py
@@ -1,7 +1,7 @@
 from inspect import Signature, Parameter
 from typing import Callable, Tuple, List, Any, Union
 
-from sigmatch.errors import SignatureMismatchError
+from sigmatch.errors import SignatureMismatchError, IncorrectArgumentsOrderError
 
 
 class SignatureMatcher:
@@ -74,26 +74,26 @@ class SignatureMatcher:
 
             if item == '.':
                 if met_name or met_star or met_double_star:
-                    raise ValueError('Positional arguments must be specified first.')
+                    raise IncorrectArgumentsOrderError('Positional arguments must be specified first.')
 
             elif item.isidentifier():
                 met_name = True
                 if met_star or met_double_star:
-                    raise ValueError('Keyword arguments can be specified after positional ones, but before unpacking.')
+                    raise IncorrectArgumentsOrderError('Keyword arguments can be specified after positional ones, but before unpacking.')
                 if item in all_met_names:
-                    raise ValueError(f'The same argument name cannot occur twice. You have a repeat of "{item}".')
+                    raise IncorrectArgumentsOrderError(f'The same argument name cannot occur twice. You have a repeat of "{item}".')
                 all_met_names.add(item)
 
             elif item == '*':
                 if met_star:
-                    raise ValueError('Unpacking of the same type (*args in this case) can be specified no more than once.')
+                    raise IncorrectArgumentsOrderError('Unpacking of the same type (*args in this case) can be specified no more than once.')
                 met_star = True
                 if met_double_star:
-                    raise ValueError('Unpacking positional arguments should go before unpacking keyword arguments.')
+                    raise IncorrectArgumentsOrderError('Unpacking positional arguments should go before unpacking keyword arguments.')
 
             elif item == '**':
                 if met_double_star:
-                    raise ValueError('Unpacking of the same type (**kwargs in this case) can be specified no more than once.')
+                    raise IncorrectArgumentsOrderError('Unpacking of the same type (**kwargs in this case) can be specified no more than once.')
                 met_double_star = True
 
     def prove_is_args(self, parameters: List[Parameter]) -> bool:

--- a/sigmatch/matcher.py
+++ b/sigmatch/matcher.py
@@ -61,7 +61,6 @@ class SignatureMatcher:
         return result
 
     def check_expected_signature(self, expected_signature: Tuple[str, ...]) -> None:
-        meet_dot = False
         meet_name = False
         meet_star = False
         meet_double_star = False
@@ -73,7 +72,6 @@ class SignatureMatcher:
                 raise ValueError(f'Only strings of a certain format can be used as symbols for function arguments: arbitrary variable names, and ".", "*", "**" strings. You used "{item}".')
 
             if item == '.':
-                meet_dot = True
                 if meet_name or meet_star or meet_double_star:
                     raise ValueError('Positional arguments must be specified first.')
 

--- a/sigmatch/matcher.py
+++ b/sigmatch/matcher.py
@@ -60,7 +60,7 @@ class SignatureMatcher:
             raise SignatureMismatchError('The signature of the callable object does not match the expected one.')
         return result
 
-    def check_expected_signature(self, expected_signature: Tuple[str]) -> None:
+    def check_expected_signature(self, expected_signature: Tuple[str, ...]) -> None:
         meet_dot = False
         meet_name = False
         meet_star = False

--- a/sigmatch/matcher.py
+++ b/sigmatch/matcher.py
@@ -75,23 +75,23 @@ class SignatureMatcher:
             if item == '.':
                 meet_dot = True
                 if meet_name or meet_star or meet_double_star:
-                    raise ValueError()
+                    raise ValueError('Positional arguments must be specified first.')
 
             elif item.isidentifier():
                 meet_name = True
                 if meet_star or meet_double_star:
-                    raise ValueError()
+                    raise ValueError('Keyword arguments can be specified after positional ones, but before unpacking.')
 
             elif item == '*':
                 if meet_star:
-                    raise ValueError()
+                    raise ValueError('Unpacking of the same type (*args in this case) can be specified no more than once.')
                 meet_star = True
                 if meet_double_star:
-                    raise ValueError()
+                    raise ValueError('Unpacking positional arguments should go before unpacking keyword arguments.')
 
             elif item == '**':
                 if meet_double_star:
-                    raise ValueError()
+                    raise ValueError('Unpacking of the same type (**kwargs in this case) can be specified no more than once.')
                 meet_double_star = True
 
     def prove_is_args(self, parameters: List[Parameter]) -> bool:

--- a/sigmatch/matcher.py
+++ b/sigmatch/matcher.py
@@ -61,9 +61,10 @@ class SignatureMatcher:
         return result
 
     def check_expected_signature(self, expected_signature: Tuple[str, ...]) -> None:
-        meet_name = False
-        meet_star = False
-        meet_double_star = False
+        met_name = False
+        met_star = False
+        met_double_star = False
+        all_met_names = set()
 
         for item in expected_signature:
             if not isinstance(item, str):
@@ -72,25 +73,28 @@ class SignatureMatcher:
                 raise ValueError(f'Only strings of a certain format can be used as symbols for function arguments: arbitrary variable names, and ".", "*", "**" strings. You used "{item}".')
 
             if item == '.':
-                if meet_name or meet_star or meet_double_star:
+                if met_name or met_star or met_double_star:
                     raise ValueError('Positional arguments must be specified first.')
 
             elif item.isidentifier():
-                meet_name = True
-                if meet_star or meet_double_star:
+                met_name = True
+                if met_star or met_double_star:
                     raise ValueError('Keyword arguments can be specified after positional ones, but before unpacking.')
+                if item in all_met_names:
+                    raise ValueError(f'The same argument name cannot occur twice. You have a repeat of "{item}".')
+                all_met_names.add(item)
 
             elif item == '*':
-                if meet_star:
+                if met_star:
                     raise ValueError('Unpacking of the same type (*args in this case) can be specified no more than once.')
-                meet_star = True
-                if meet_double_star:
+                met_star = True
+                if met_double_star:
                     raise ValueError('Unpacking positional arguments should go before unpacking keyword arguments.')
 
             elif item == '**':
-                if meet_double_star:
+                if met_double_star:
                     raise ValueError('Unpacking of the same type (**kwargs in this case) can be specified no more than once.')
-                meet_double_star = True
+                met_double_star = True
 
     def prove_is_args(self, parameters: List[Parameter]) -> bool:
         """Checking for unpacking of positional arguments."""

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from sigmatch import SignatureMatcher, SignatureMismatchError
+from sigmatch import SignatureMatcher, SignatureMismatchError, IncorrectArgumentsOrderError
 
 
 def test_random_functions():
@@ -366,5 +366,5 @@ def test_bad_string_as_parameter():
     ],
 )
 def test_wrong_order(before, message, after):
-    with pytest.raises(ValueError, match=re.escape(message)):
+    with pytest.raises(IncorrectArgumentsOrderError, match=re.escape(message)):
         SignatureMatcher(before, after)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from sigmatch import SignatureMatcher, SignatureMismatchError
@@ -333,3 +335,13 @@ def test_check_method():
 
     assert SignatureMatcher('.', '.', '.').match(Kek().kek)
     assert not SignatureMatcher().match(Kek().kek)
+
+
+def test_if_parameter_is_not_string():
+    with pytest.raises(TypeError, match=re.escape('Only strings can be used as symbolic representation of function parameters. You used "1" (int).')):
+        SignatureMatcher('.', 1, '.')
+
+
+def test_bad_string_as_parameter():
+    with pytest.raises(ValueError, match=re.escape('Only strings of a certain format can be used as symbols for function arguments: arbitrary variable names, and ".", "*", "**" strings. You used "   ".')):
+        SignatureMatcher('.', '   ')

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -361,6 +361,8 @@ def test_bad_string_as_parameter():
 
         ('*', '*', 'Unpacking of the same type (*args in this case) can be specified no more than once.'),
         ('**', '**', 'Unpacking of the same type (**kwargs in this case) can be specified no more than once.'),
+
+        ('kek', 'kek', 'The same argument name cannot occur twice. You have a repeat of "kek".'),
     ],
 )
 def test_wrong_order(before, message, after):

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -324,3 +324,12 @@ def test_class_with_call_dunder_object_is_callable():
 
     assert SignatureMatcher('.', '.', '.').match(Kek())
     assert not SignatureMatcher().match(Kek())
+
+
+def test_check_method():
+    class Kek:
+        def kek(self, a, b, c):
+            pass
+
+    assert SignatureMatcher('.', '.', '.').match(Kek().kek)
+    assert not SignatureMatcher().match(Kek().kek)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -347,12 +347,22 @@ def test_bad_string_as_parameter():
         SignatureMatcher('.', '   ')
 
 
-def test_order_dot_after_another():
-    with pytest.raises(ValueError, match='Positional arguments must be specified first.'):
-        SignatureMatcher('kek', '.')
+@pytest.mark.parametrize(
+    'before,after,message',
+    [
+        ('kek', '.', 'Positional arguments must be specified first.'),
+        ('*', '.', 'Positional arguments must be specified first.'),
+        ('**', '.', 'Positional arguments must be specified first.'),
 
-    with pytest.raises(ValueError, match='Positional arguments must be specified first.'):
-        SignatureMatcher('*', '.')
+        ('*', 'kek', 'Keyword arguments can be specified after positional ones, but before unpacking.'),
+        ('**', 'kek', 'Keyword arguments can be specified after positional ones, but before unpacking.'),
 
-    with pytest.raises(ValueError, match='Positional arguments must be specified first.'):
-        SignatureMatcher('**', '.')
+        ('**', '*', 'Unpacking positional arguments should go before unpacking keyword arguments.'),
+
+        ('*', '*', 'Unpacking of the same type (*args in this case) can be specified no more than once.'),
+        ('**', '**', 'Unpacking of the same type (**kwargs in this case) can be specified no more than once.'),
+    ],
+)
+def test_wrong_order(before, message, after):
+    with pytest.raises(ValueError, match=re.escape(message)):
+        SignatureMatcher(before, after)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -345,3 +345,14 @@ def test_if_parameter_is_not_string():
 def test_bad_string_as_parameter():
     with pytest.raises(ValueError, match=re.escape('Only strings of a certain format can be used as symbols for function arguments: arbitrary variable names, and ".", "*", "**" strings. You used "   ".')):
         SignatureMatcher('.', '   ')
+
+
+def test_order_dot_after_another():
+    with pytest.raises(ValueError, match='Positional arguments must be specified first.'):
+        SignatureMatcher('kek', '.')
+
+    with pytest.raises(ValueError, match='Positional arguments must be specified first.'):
+        SignatureMatcher('*', '.')
+
+    with pytest.raises(ValueError, match='Positional arguments must be specified first.'):
+        SignatureMatcher('**', '.')


### PR DESCRIPTION
A little but important update.

- Added checks for initialization arguments. The arguments must be correct and follow the correct order. If the order is violated, the `IncorrectArgumentsOrderError` is now raised.
- Added a bit of testing of the old functionality.